### PR TITLE
Update rotation extraction and add rotation sin

### DIFF
--- a/src/clams/construct_variable.py
+++ b/src/clams/construct_variable.py
@@ -16,6 +16,7 @@ def construct_variables():
 	"""
 	rotation_diff_list = []
 	rotation_average_list = []
+	rotation_sine_list = []
 	scaling_diff_list = []
 	mean_diff_list = []
 	gaussian_mean_vector_angle_diff_list = []
@@ -43,6 +44,7 @@ def construct_variables():
 
 			rotation_diff_list.append(input_variables["rotation_diff"])
 			rotation_average_list.append(input_variables["rotation_average"])
+			rotation_sine_list.append(input_variables["rotation_sine"])
 			scaling_diff_list.append(input_variables["scaling_diff"])
 			mean_diff_list.append(input_variables["mean_diff"])
 			scaling_size_list.append(input_variables["scaling_size"])
@@ -62,6 +64,7 @@ def construct_variables():
 	df = pd.DataFrame({
 		"rotation_diff": rotation_diff_list,
 		"rotation_average": rotation_average_list,
+		"rotation_sine": rotation_sine_list,
 		"scaling_diff": scaling_diff_list,
 		"mean_diff": mean_diff_list,
 		"prob_single": prob_single_list,

--- a/src/clams/train_and_predict.py
+++ b/src/clams/train_and_predict.py
@@ -165,6 +165,7 @@ with_scaling_arr = [
 	"rotation_average",
 	"gaussian_mean_vector_angle_diff",
 	"gaussian_mean_vector_angle_average",
+	"rotation_sine"
 ]
 
 # find_best_variable_combination(with_scaling_arr)


### PR DESCRIPTION
I've updated angle extraction methods from np.linalg.svd to np.linalg.eig.
Also, the updated code always guarantees the following:
1) angles in the range [0, pi]
2) scaling factor returned from the function "decompose_covariance_matrix" in helpers.py are now ordered (previously, SVD guarantees this factor but could not guarantee the correct rotation).

Moreover, I've updated one additional variable for the autoML -- sin function for the rotation difference.